### PR TITLE
Internal fields implementation

### DIFF
--- a/ckanext/yukon_2025_design/action.py
+++ b/ckanext/yukon_2025_design/action.py
@@ -1,0 +1,84 @@
+import ckan.plugins.toolkit as toolkit
+import ckan.authz as authz
+import ckan.model as model
+
+
+def is_user_editor_of_org(org_id, user_id):
+    capacity = authz.users_role_for_group_or_org(org_id, user_id)
+    return capacity == "editor"
+
+
+def is_user_admin_of_org(org_id, user_id):
+    capacity = authz.users_role_for_group_or_org(org_id, user_id)
+    return capacity == "admin"
+
+
+def is_user_sysadmin(user_id):
+    user = model.User.get(user_id)
+    if user:
+        return user.sysadmin
+    return False
+
+
+def can_view_internal_data(user, org_id):
+    if not user:
+        return False
+
+    user_obj = model.User.get(user)
+    if not user_obj:
+        return False
+
+    user_id = user_obj.id
+
+    if is_user_sysadmin(user_id):
+        return True
+    if is_user_admin_of_org(org_id, user_id):
+        return True
+    if is_user_editor_of_org(org_id, user_id):
+        return True
+    return False
+
+@toolkit.side_effect_free
+@toolkit.chained_action
+def package_show(up_func, context, data_dict):
+    user = context.get("user")
+    result = up_func(context, data_dict)
+    org_id = result['organization']['id']
+    if not can_view_internal_data(user, org_id):
+        result.pop('internal_contact_name', None)
+        result.pop('internal_contact_email', None)
+        result.pop('internal_notes', None)
+    
+    return result
+
+@toolkit.side_effect_free
+@toolkit.chained_action
+def package_search(up_func, context, data_dict):
+    user = context.get("user")
+    result = up_func(context, data_dict)
+    pkg_dicts = result['results']
+
+    for pkg_dict in pkg_dicts:
+        org_id = pkg_dict['organization']['id']
+        if not can_view_internal_data(user, org_id):
+            pkg_dict.pop('internal_contact_name', None)
+            pkg_dict.pop('internal_contact_email', None)
+            pkg_dict.pop('internal_notes', None)
+
+    return result
+
+
+@toolkit.side_effect_free
+@toolkit.chained_action
+def current_package_list_with_resources(up_func, context, data_dict):
+    user = context.get("user")
+    results = up_func(context, data_dict)
+
+    for result in results:
+        org_id = result['organization']['id']
+        if not can_view_internal_data(user, org_id):
+            result.pop('internal_contact_name', None)
+            result.pop('internal_contact_email', None)
+            result.pop('internal_notes', None)
+
+    return results

--- a/ckanext/yukon_2025_design/plugin.py
+++ b/ckanext/yukon_2025_design/plugin.py
@@ -1,16 +1,21 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+import ckanext.yukon_2025_design.action as action
 
 
 class Yukon2025DesignPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
-    
-
-    # IConfigurer
+    plugins.implements(plugins.IActions)
 
     def update_config(self, config_):
         toolkit.add_template_directory(config_, "templates")
         toolkit.add_public_directory(config_, "public")
         toolkit.add_resource("assets", "yukon_2025_design")
 
-    
+    def get_actions(self):
+        return {
+            'package_show': action.package_show,
+            'package_search': action.package_search,
+            'current_package_list_with_resources': action.current_package_list_with_resources
+        }
+


### PR DESCRIPTION
This PR contains backend logic for hiding internal fields for the non-authenticated users in the UI and API calls
Internal fields are:
1. Internal contact name
2. Internal contact email
3. Internal notes

Modified API actions are:
1. package_show
2. package_search
3. current_package_list_with_resources

This fixes #10