### PR TITLE
Replace footer feedback email with localized online feedback form

### DIFF
--- a/ckanext/yukondesign/templates/footer.html
+++ b/ckanext/yukondesign/templates/footer.html
@@ -158,28 +158,32 @@
       </div>
       <div class="footer__legal font-light w-auto flex pt-2 pt-md-4 pb-2 ms-1 text-end">
         ©&nbsp;{{ h.get_current_year() }}&nbsp;<a href="https://yukon.ca{% if lang_prefix == '/fr' %}/fr{% endif %}">{{ _("Government of Yukon") }}</a>
+        
         <div class="footer__feedback mt-1" style="font-weight: normal;">
-          {% if lang_prefix == '/fr' %}
-            <a id="footer-feedback-link" href="#">{{ _("Formuler un commentaire") }}</a>
-          {% else %}
-            <a id="footer-feedback-link" href="#">{{ _("Submit website feedback") }}</a>
-          {% endif %}
+          {% set current_url = request.url | urlencode %}
+
+          {% set feedback_url = (
+            "https://forms2.service.yukon.ca/content/yukon-forms/ca/fr/hpw/Parlez-nous-de-votre-experience-dutilisation-des-services-en-ligne.html"
+            if lang_prefix == "/fr"
+            else
+            "https://forms2.service.yukon.ca/content/yukon-forms/ca/en/hpw/submit-feedback-about-your-digital-service-experience.html"
+          ) %}
+
+          {% set feedback_url = feedback_url
+            ~ "?onlineService=Open%20government%20portal"
+            ~ "&url_referrer=" ~ current_url
+            ~ ("&afAcceptLang=fr-ca" if lang_prefix == "/fr" else "")
+          %}
+
+          <a
+            id="footer-feedback-link"
+            class="yg-submit-feedback-link"
+            href="{{ feedback_url }}"
+            target="_blank"
+          >
+            {{ _("Formuler un commentaire") if lang_prefix == "/fr" else _("Submit website feedback") }}
+          </a>
         </div>
-        <script>
-          document.addEventListener('DOMContentLoaded', function() {
-            var feedbackLink = document.getElementById('footer-feedback-link');
-            if (!feedbackLink) return;
-            var pageUrl = window.location.href;
-            var isFrench = feedbackLink.textContent.trim() === 'Formuler un commentaire';
-            if (isFrench) {
-              var mailto = 'mailto:eservices@yukon.ca?subject=Des%20suggestions%20pour%20am%C3%A9liorer%20le%20portail%20de%20gouvernement%20ouvert&body=Adresse%20de%20la%20page%20Web%3A%0A' + encodeURIComponent(pageUrl) + '%0A%0ADes%20commentaires%20sur%20le%20site%20%3F%0A%0A%0A%0AQue%20pouvons-nous%20faire%20pour%20am%C3%A9liorer%20ce%20service%20%3F%0A%0A';
-              feedbackLink.setAttribute('href', mailto);
-            } else {
-              var mailto = 'mailto:eservices@yukon.ca?subject=Open%20government%20portal%20website%20feedback&body=Webpage%20address%3A%0A' + encodeURIComponent(pageUrl) + '%0A%0AWhat\'s%20your%20feedback%3F%0A%0A%0A%0AWhat%20can%20we%20do%20to%20improve%20this%20service%3F%0A%0A';
-              feedbackLink.setAttribute('href', mailto);
-            }
-          });
-        </script>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Issue: #154 

**Changes:**

Replaces the footer “Submit website feedback” email link with the new Yukon online feedback form.

- Uses locale-aware form URLs (English / French)
- Passes the current page URL as a URL-encoded referrer
- Includes afAcceptLang=fr-ca for French pages only
- Opens the feedback form in a new tab
