### PR TITLE
Potential fix for missing Matomo sync download totals for non-data schema types

### DIFF
--- a/ckanext/yukondesign/matomo_sync.py
+++ b/ckanext/yukondesign/matomo_sync.py
@@ -254,13 +254,13 @@ def _iter_records(payload):
                         yield row
 
 
-def _sum_downloads_from_map(download_map, candidate_urls, package_id):
+def _sum_downloads_from_map(download_map, candidate_urls, package_id, package_type):
     """Sum download hits for a dataset's resource URLs from a pre-fetched site-wide map.
 
     Uploaded files: match any map key that contains the package resource path prefix.
     External URLs: match by normalised URL.
     """
-    package_prefix = "/data/{}/resource/".format(package_id)
+    package_prefix = "/{}/{}/resource/".format(package_type, package_id)
     total = 0
     for url in candidate_urls:
         if not url:
@@ -429,8 +429,9 @@ def _dataset_download_urls(package):
 
         if getattr(resource, "url_type", "") == "upload" and site_url:
             urls.append(
-                "{}/data/{}/resource/{}/download/{}".format(
+                "{}/{}/{}/resource/{}/download/{}".format(
                     site_url,
+                    package.type,
                     package.id,
                     resource.id,
                     resource_url.lstrip("/"),
@@ -552,10 +553,10 @@ def sync_usage_data(dry_run=False, limit=None, offset=None, dataset_refs=None):
                     page_urls, periods_3y, periods_90d
                 )
                 downloads = _sum_downloads_from_map(
-                    download_map_3y, download_urls, package.id
+                    download_map_3y, download_urls, package.id, package.type
                 )
                 download_90_days = _sum_downloads_from_map(
-                    download_map_90d, download_urls, package.id
+                    download_map_90d, download_urls, package.id, package.type
                 )
 
                 payload = {


### PR DESCRIPTION
Right now download totals are missing for information, atipp-requests, and pia-summaries schema type resources.

This attempts to fix that issue by including the package type in the pre-fetched map of resource URLs (which previously had a hardcoded `/data/` component to the resource URL path being compared, instead of e.g. `/information/` or other schema types).

Resource download URLs for non-data schema types are, for example:

```
https://open.yukon.ca/information/090164ac-71ff-4b6f-ac88-81b5b4bbab47/resource/cb74597e-1540-3759-89c2-3350114ed7b6/download/whitecap_groundwater_report_0.pdf
https://open.yukon.ca/access-requests/4f6ba8db-5058-48b5-85a1-ba9fe4c9adbb/resource/c271c34a-ea72-4e6d-94fd-2cf0bcb1f1c9/download/25-143-final-response.pdf
etc.
```

This PR has not yet been tested locally. The main unknown factor is if `package.type` is retrievable as expected.