### PR TITLE
Fix for featured dataset updates on homepage

### DIFF
--- a/ckanext/yukondesign/action.py
+++ b/ckanext/yukondesign/action.py
@@ -284,7 +284,7 @@ def package_set_featured(context, data_dict):
         # Fetch all current featured datasets
         current_featured = toolkit.get_action('package_search')(
             {'ignore_auth': True},
-            {'fq': 'is_featured:True', 'rows': 1000}
+            {'fq': 'is_featured:true', 'rows': 1000}
         )['results']
         
         log.info(f"Found {len(current_featured)} currently featured datasets")
@@ -305,7 +305,7 @@ def package_set_featured(context, data_dict):
             if package_obj:
                 log.info(f"Removing featured flag from package {pkg_id}")
                 # Update the extras directly without changing metadata_modified
-                _update_package_extra(package_obj, 'is_featured', 'False')
+                _update_package_extra(package_obj, 'is_featured', 'false')
 
         # Set the "is_featured" flag for the new datasets
         for dataset_id in dataset_ids:
@@ -314,7 +314,7 @@ def package_set_featured(context, data_dict):
                 log.info(f"Setting featured flag for package {dataset_id}")
                 log.info(f"Pkg ID: {package_obj.id}, Name: {package_obj.name}")
                 # Update the extras directly without changing metadata_modified
-                _update_package_extra(package_obj, 'is_featured', 'True')
+                _update_package_extra(package_obj, 'is_featured', 'true')
             else:
                 log.error(f"No package object found for {dataset_id}")
 

--- a/ckanext/yukondesign/helpers.py
+++ b/ckanext/yukondesign/helpers.py
@@ -210,7 +210,7 @@ def get_featured_datasets():
         # Get all packages with is_featured extra set to True
         extras_query = model.Session.query(model.PackageExtra).filter(
             model.PackageExtra.key == 'is_featured',
-            model.PackageExtra.value == 'True'
+            model.PackageExtra.value == 'true'
         ).all()
         
         for extra in extras_query:


### PR DESCRIPTION
The featured datasets logic for the homepage display had inconsistent string logic (`"True"` versus `"true"`) that might have varied between the search index and direct database queries in [`get_featured_datasets`](https://github.com/ytgov/ckanext-yukondesign/blob/main/ckanext/yukondesign/helpers.py#L196).

Prior to this fix, existing featured datasets weren't being successfully removed and replaced when the `package_set_featured` API call was made. New featured datasets also were not being added.

This pull request (hopefully) resolves this issue. As usual, this has not been tested locally. 😜

The `is_featured` flag can also be set using `package_patch` ([example R API call here](https://github.com/ytgov/ckan-system-helper-tools-r/blob/main/manual_set_featured_reset.R)) but this changes the package's metadata date modified to today's date which is not intended.

A more rigorous approach to this might have replaced string `"True"` values with logical `True` values, but I wasn't sure if that would have unintended consequences either for search indexing or API calls. The string approach here is similar to the earlier (working) behaviour from the extension's initial release. 